### PR TITLE
we are not paranoid.

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -156,8 +156,6 @@ void *monitor_proc(void *unused) {
     time_t current = time(NULL);
     time_t elapsed = current - start;
 
-    if(!elapsed)
-      continue; // be paranoid and avoid divide-by-zero exceptions
 
     fprintf(stderr,"\033[u\033[KHashes: %-20"PRIu64"  Time: %-10d  Speed: %-"PRIu64"",
            loop, (int)elapsed, loop / elapsed);


### PR DESCRIPTION
sleep(1) does magically increment time() so elapsed is never 0
